### PR TITLE
Pin requests-file to 1.5.1 for Jython compat

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ beautifulsoup4
 html5lib
 urllib3
 tldextract==2.2.3
+requests-file==1.5.1


### PR DESCRIPTION
Hi,

Following the setup instructions resulted in the following warning in Burp:

<img width="1130" height="234" alt="image" src="https://github.com/user-attachments/assets/7a4e5d91-07a0-4d11-b845-46ba6c90c5b3" />

As it turned out:
tldextract==2.2.3 depends on requests-file>=1.4. 
When pip resolves this, it installs the latest requests-file (currently 3.0.1), whose `__init__.py` uses Python 3 type hint syntax:
`def __init__(self, set_content_length: bool = True) -> None:`
Jython (Python 2.7) cannot parse `:` and `->` type annotations.
The last requests-file version that supports Python 2/Jython is 1.5.1.

Made a change in requirements.txt to fix this. Hope it doesn't break anything.

Cheers,
zsirfoka